### PR TITLE
improve instructions for el capitan

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ This script implements the Unison fswatch protocol (see `/src/fswatch.ml`)
 and is intended to be installed as `unison-fsmonitor` in the PATH in OS X. This is the
 missing puzzle piece for repeat = watch support for Unison in in OS X.
 
-Example installation: `sudo ln -s ~/unox/unox.py /usr/bin/unison-fsmonitor`
+Example installation:
+`sudo ln -s ~/unox/unox.py /usr/bin/unison-fsmonitor`
+
+For El Captain, unison is installed in /usr/local/bin:
+`sudo ln -s ~/unox/unox.py /usr/local/bin/unison-fsmonitor`
 
 Dependencies: sudo pip install macfsevents
 


### PR DESCRIPTION
Mac OSX El Capitan changes the location where unison is installed to /usr/local/sbin. I updated the instructions to reflect that.
