### PR TITLE
Switch from fsevents to watchdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ missing puzzle piece for repeat = watch support for Unison in in OS X.
 
 Example installation: `sudo ln -s ~/unox/unox.py /usr/bin/unison-fsmonitor`
 
-Dependencies: sudo pip install macfsevents
+Dependencies: sudo pip install watchdog
 
 Licence: MPLv2 (https://www.mozilla.org/MPL/2.0/)

--- a/unox.py
+++ b/unox.py
@@ -14,28 +14,29 @@
 # and is intended to be installed as unison-fsmonitor in the PATH in OS X. This is the
 # missing puzzle piece for repeat = watch support for Unison in in OS X.
 #
-# Dependencies: pip install macfsevents
+# Dependencies: pip install watchdog
 #
 # Licence: MPLv2 (https://www.mozilla.org/MPL/2.0/)
 
 import sys
 import os
 import time
-import fsevents
 import urllib
 import traceback
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
 
 my_log_prefix = "[unox]"
 
 _in_debug = "--debug" in sys.argv
 _in_debug_plus = False
 
-# Global MacFSEvents observer.
-observer = fsevents.Observer()
+# Global watchdog observer.
+observer = Observer()
 observer.start()
 
 # Dict of monitored replicas.
-# Replica hash mapped to fsevents.Stream objects.
+# Replica hash mapped to watchdog.observers.api.ObservedWatch objects.
 replicas = {}
 
 # Dict of pending replicas that are beeing waited on.
@@ -95,7 +96,11 @@ def recvCmd():
     # We flush before stalling on read instead of
     # flushing every write for optimization purposes.
     sys.stdout.flush()
-    line = sys.stdin.readline()
+    try:
+        line = sys.stdin.readline()
+    except KeyboardInterrupt:
+        sys.exit(0)
+
     if not line.endswith("\n"):
         # End of stream means we're done.
         if _in_debug: _debug("stdin closed, exiting")
@@ -147,6 +152,30 @@ def triggerReplica(replica, local_path_toks):
     cur_lvl[leaf_path_tok] = True
     _debug_triggers()
 
+
+class Handler(FileSystemEventHandler):
+    def __init__(self, fspath, replica):
+        self.replica = replica
+        self.fspath = fspath
+
+    def dispatch(self, event):
+        path = event.src_path
+        try:
+            if not path.startswith(self.fspath):
+                return warn("unexpected file event at path [" + path + "] for [" + self.fspath + "]")
+            local_path = path[len(self.fspath):]
+            local_path_toks = pathTokenize(local_path)
+            if _in_debug: _debug("replica:[" + self.replica + "] file event @[" + local_path + "] (" + path + ")")
+            triggerReplica(self.replica, local_path_toks)
+        except Exception as e:
+            # Because python is a horrible language it has a special behavior for non-main threads that
+            # fails to catch an exception. Instead of crashing the process, only the thread is destroyed.
+            # We fix this with this catch all exception handler.
+            sys.stderr.write(format_exception(e))
+            sys.stderr.flush()
+            os._exit(1)
+
+
 # Starts monitoring of a replica.
 def startReplicaMon(replica, fspath, path):
     global replicas, observer
@@ -154,33 +183,18 @@ def startReplicaMon(replica, fspath, path):
         # Ensure fspath has trailing slash.
         fspath = os.path.join(fspath, "")
         if _in_debug: _debug("start monitoring of replica [" + replica + "] [" + fspath + "]")
-        def replicaFileEventCallback(path, mask):
-            try:
-                if not path.startswith(fspath):
-                    return warn("unexpected file event at path [" + path + "] for [" + fspath + "]")
-                local_path = path[len(fspath):]
-                local_path_toks = pathTokenize(local_path)
-                if _in_debug: _debug("replica:[" + replica + "] file event @[" + local_path + "] (" + path + ")")
-                triggerReplica(replica, local_path_toks)
-            except Exception as e:
-                # Because python is a horrible language it has a special behavior for non-main threads that
-                # fails to catch an exception. Instead of crashing the process, only the thread is destroyed.
-                # We fix this with this catch all exception handler.
-                sys.stderr.write(format_exception(e))
-                sys.stderr.flush()
-                os._exit(1)
         try:
             # OS X has no interface for "file level" events. You would have to implement this manually in userspace,
             # and compare against a snapshot. This means there's no point in us doing it, better leave it to Unison.
             if _in_debug: _debug("replica:[" + replica + "] watching path [" + fspath + "]")
-            stream = fsevents.Stream(replicaFileEventCallback, fspath)
-            observer.schedule(stream)
-        except (FileNotFoundError, NotADirectoryError) as e:
+            handler = Handler(fspath, replica)
+            watch = observer.schedule(handler, fspath)
+        except Exception as e:
             sendError(str(e))
         replicas[replica] = {
-            "stream": stream,
+            "watch": watch,
             "fspath": fspath
-    	}
+        }
     sendAck()
     while True:
         [cmd, args] = recvCmd();
@@ -257,9 +271,9 @@ def main():
             if not replica in replicas:
                 warn("unknown replica: " + replica)
                 continue
-            stream = replicas[replica]["stream"]
-            if stream is not None:
-                observer.unschedule(stream)
+            watch = replicas[replica]["watch"]
+            if watch is not None:
+                observer.unschedule(watch)
             del replicas[replica]
             if replica in triggered_reps:
                 del triggered_reps[replica]
@@ -272,6 +286,6 @@ if __name__ == '__main__':
         main()
     finally:
         for replica in replicas:
-            observer.unschedule(replicas[replica]["stream"])
+            observer.unschedule(replicas[replica]["watch"])
         observer.stop()
         observer.join()


### PR DESCRIPTION
This change swaps out the base fsevents API for watchdog. It's not all
that well tested, but the basics are working.

In my testing on 10.11, fsevents was causing indeterminate delays of up to ~10 seconds for events to be triggered. Using watchdog results in the expected "immediate" behavior.
