### PR TITLE
Fix the DEBUG API command.

### DIFF
--- a/unox.py
+++ b/unox.py
@@ -240,7 +240,7 @@ def reportRecursiveChanges(local_path, cur_lvl):
 
 
 def main():
-    global replicas, pending_reps, triggered_reps
+    global replicas, pending_reps, triggered_reps, _in_debug
     # Version handshake.
     sendCmd("VERSION", ["1"])
     [cmd, args] = recvCmd();


### PR DESCRIPTION
The `_in_debug` local was shadowing the global `_in_debug` variable in
`main()`, causing debug messages not to appear as designed when the
`DEBUG` command was sent.

Tested in Python 2.7.