### PR TITLE
updated readme to reference homebrew installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,19 @@ This script implements the Unison fswatch protocol (see `/src/fswatch.ml`)
 and is intended to be installed as `unison-fsmonitor` in the PATH in OS X. This is the
 missing puzzle piece for repeat = watch support for Unison in in OS X.
 
-Example installation:
+### Installation view homebrew
+    
+    brew tap eugenmaer/dockersync
+    brew install eugenmayer/dockersync/unox
+
+### Manual installation:
 `sudo ln -s ~/unox/unox.py /usr/bin/unison-fsmonitor`
 
 For El Captain, unison is installed in /usr/local/bin:
 `sudo ln -s ~/unox/unox.py /usr/local/bin/unison-fsmonitor`
 
 Dependencies: sudo pip install watchdog
+
+### License
 
 Licence: MPLv2 (https://www.mozilla.org/MPL/2.0/)


### PR DESCRIPTION
I went forward and created a homebrew tap and changed unox the way it is needed to be installaed using homebrew, including adding a setup.py.

